### PR TITLE
Added Update Additional Salary

### DIFF
--- a/core_banking/api/additional_salary.py
+++ b/core_banking/api/additional_salary.py
@@ -1,0 +1,20 @@
+import frappe, json
+
+@frappe.whitelist()
+def update_additional_salary(payload):
+    data = json.loads(payload)
+
+    if data.get("update_amount"):
+        sql = "UPDATE `tabAdditional Salary` SET amount ={} WHERE name ='{}' AND docstatus=1 ;".format(data.get("amount"),data.get("name"))
+        frappe.db.sql(sql)
+        frappe.db.commit()
+    return data
+    # {'update_amount': 1, 'amount': 62758, 'update_balance': 0, 'amount_payable': 0, 'confirmation': '203', 'name': 'HR-ADS-22-03-00001'}
+@frappe.whitelist()
+def stop_additional_salary(docname,stop_date):
+    frappe.msgprint("Stopping {} effective {}".format(docname,stop_date))
+    sql = "UPDATE `tabAdditional Salary` SET to_date ='{}' WHERE name ='{}' AND docstatus=1 ;".format(stop_date,docname)
+    frappe.db.sql(sql)
+    frappe.db.commit()
+    data = dict(docname=docname,stop_date=stop_date)
+    return data

--- a/core_banking/hooks.py
+++ b/core_banking/hooks.py
@@ -14,8 +14,13 @@ app_license = "MIT"
 
 # include js, css files in header of desk.html
 app_include_css = ["/assets/core_banking/css/custom_table.css"]
-app_include_js = ["/assets/core_banking/js/custom_scripts/member.js","/assets/core_banking/js/custom_scripts/payment_entry.js",
-"/assets/core_banking/js/custom_scripts/pension_contributions_upload.js","/assets/core_banking/js/custom_scripts/payroll_entry.js"]
+app_include_js = [
+    "/assets/core_banking/js/custom_scripts/member.js",
+    "/assets/core_banking/js/custom_scripts/payment_entry.js",
+    "/assets/core_banking/js/custom_scripts/additional_salary.js",
+    "/assets/core_banking/js/custom_scripts/pension_contributions_upload.js",
+    "/assets/core_banking/js/custom_scripts/payroll_entry.js",
+]
 
 # include js, css files in header of web template
 # web_include_css = "/assets/core_banking/css/core_banking.css"
@@ -46,7 +51,7 @@ app_include_js = ["/assets/core_banking/js/custom_scripts/member.js","/assets/co
 
 # website user home page (by Role)
 # role_home_page = {
-#	"Role": "home_page"
+# 	"Role": "home_page"
 # }
 
 # Generators
@@ -96,30 +101,37 @@ app_include_js = ["/assets/core_banking/js/custom_scripts/member.js","/assets/co
 # Document Events
 # ---------------
 # Hook on document methods and events
-fixtures =[dict(dt="Report", filters=dict(module="Core Banking")),dict(dt="Print Format", filters=dict(name="Company Totals"))]
+fixtures = [
+    dict(dt="Report", filters=dict(module="Core Banking")),
+    dict(dt="Print Format", filters=dict(name="Company Totals")),
+]
 doc_events = {
-	"Member": {
-		"after_insert": "core_banking.api.member.make_member_customer",
-		"before_save": ["core_banking.api.member.set_date_of_retirement",
-						"core_banking.api.member.validate_percentages",
-						"core_banking.api.member.validate_transfers_in"],
-		# "on_trash": "method"
-	},
-	"Pension Contributions Upload":{
-		"before_save":"core_banking.api.member.populate_upload",
-		"before_submit":"core_banking.api.member.post_pension_schedule_hook"
-	},
-	"Salary Slip":{
-		"before_save":["core_banking.core_banking_payroll.salary_slip.salary_slip_save"],
-		"on_submit":["core_banking.api.payroll_entry.override_salary_slip_submit"],
-		"before_submit":["core_banking.api.payroll_entry.override_salary_slip_submit"]
-		
-	},
-	"Payroll Entry":{
-		"before_save":["core_banking.api.payroll_entry.set_title_field"],
-		"on_update_after_submit":["core_banking.api.payroll_entry.process_approved_payrolls"]
-		
-	}
+    "Member": {
+        "after_insert": "core_banking.api.member.make_member_customer",
+        "before_save": [
+            "core_banking.api.member.set_date_of_retirement",
+            "core_banking.api.member.validate_percentages",
+            "core_banking.api.member.validate_transfers_in",
+        ],
+        # "on_trash": "method"
+    },
+    "Pension Contributions Upload": {
+        "before_save": "core_banking.api.member.populate_upload",
+        "before_submit": "core_banking.api.member.post_pension_schedule_hook",
+    },
+    "Salary Slip": {
+        "before_save": [
+            "core_banking.core_banking_payroll.salary_slip.salary_slip_save"
+        ],
+        "on_submit": ["core_banking.api.payroll_entry.override_salary_slip_submit"],
+        "before_submit": ["core_banking.api.payroll_entry.override_salary_slip_submit"],
+    },
+    "Payroll Entry": {
+        "before_save": ["core_banking.api.payroll_entry.set_title_field"],
+        "on_update_after_submit": [
+            "core_banking.api.payroll_entry.process_approved_payrolls"
+        ],
+    },
 }
 
 # Scheduled Tasks
@@ -171,24 +183,22 @@ doc_events = {
 # --------------------
 
 user_data_fields = [
-	{
-		"doctype": "{doctype_1}",
-		"filter_by": "{filter_by}",
-		"redact_fields": ["{field_1}", "{field_2}"],
-		"partial": 1,
-	},
-	{
-		"doctype": "{doctype_2}",
-		"filter_by": "{filter_by}",
-		"partial": 1,
-	},
-	{
-		"doctype": "{doctype_3}",
-		"strict": False,
-	},
-	{
-		"doctype": "{doctype_4}"
-	}
+    {
+        "doctype": "{doctype_1}",
+        "filter_by": "{filter_by}",
+        "redact_fields": ["{field_1}", "{field_2}"],
+        "partial": 1,
+    },
+    {
+        "doctype": "{doctype_2}",
+        "filter_by": "{filter_by}",
+        "partial": 1,
+    },
+    {
+        "doctype": "{doctype_3}",
+        "strict": False,
+    },
+    {"doctype": "{doctype_4}"},
 ]
 
 # Authentication and authorization

--- a/core_banking/public/js/custom_scripts/additional_salary.js
+++ b/core_banking/public/js/custom_scripts/additional_salary.js
@@ -1,0 +1,154 @@
+frappe.ui.form.on('Additional Salary', {
+	refresh(frm) {
+		if (frm.doc.docstatus ==1){
+    		frm.add_custom_button(__("Stop Deduction / Earning"), function(){
+                showStopDialog(frm)
+            });
+            frm.add_custom_button(__("Update Deduction / Earning Terms"), function(){
+                 showUpdateSalaryComponentTerms(frm)
+            })
+	    }}
+})
+
+function showMakeAdditionalSalary(frm){
+    var d = new frappe.ui.Dialog({
+    'fields': [
+        {'fieldname': 'ht', 'fieldtype': 'HTML'},
+        {'fieldname': 'start_date', 'fieldtype': 'From Date', 'reqd':1, 'default':frm.doc.payroll_date},
+        {'fieldname': 'end_date', 'fieldtype': 'End Date', 'reqd':1}
+    ],
+    primary_action: function(){
+        let values = d.get_values()
+        d.hide();
+        show_alert();
+    }
+});
+d.fields_dict.ht.$wrapper.html('Hello World');
+d.show();
+}
+
+function showUpdateSalaryComponentTerms(frm){
+    // if (!frm.doc.is_recurring){
+    //     frappe.throw("Sorry, this transaction is applicable for recurring Additional Salary Documents")
+    // }
+    frappe.prompt([
+        {
+            //label: 'First Name',
+            fieldname: 'text_html',
+            fieldtype: 'HTML',
+            options: `<p style='color:red'> WARNING!! You are about to UPDATE <strong>${frm.doc.salary_component} (${formattedAmount(parseFloat(frm.doc.amount))})</strong> for <strong>${frm.doc.employee_name}-${frm.doc.employee}. Please cross-check before submit to MAKE SURE of the details you provide.</strong></p>`
+        },
+        
+        {
+            label: 'Update Amount',
+            fieldname: 'update_amount',
+            fieldtype: 'Check',
+            description: 'If ticked the monthly charges will be updated.',
+            reqd: 1, 
+            default : true
+        },
+            {
+            label: 'Amount On',
+            fieldname: 'amount',
+            fieldtype: 'Currency',
+            description: 'New Monthly Charges.',
+            reqd: 1
+        },
+        {
+            label: 'Update Balance',
+            fieldname: 'update_balance',
+            fieldtype: 'Check',
+            description: 'If ticked the balance will be updated.',
+            reqd: 1, 
+            default : false
+        },
+         {
+            label: 'Balance',
+            fieldname: 'amount_payable',
+            fieldtype: 'Currency',
+            description: 'Account balance as at the effective date.',
+            reqd: 1,
+            default: frm.doc.amount_payable
+             
+         },
+        
+      {
+            label: 'Attachment',
+            fieldname: 'attachment_evidence',
+            fieldtype: 'Attach',
+            description: 'Attachment as evidence of this transaction.',
+            reqd: 0
+        },
+         {
+            label: 'Confirmation',
+            fieldname: 'confirmation',
+            fieldtype: 'Data',
+            description: 'Please enter the Staff PF Number to Confirm transaction.',
+            reqd: 1
+        }
+             
+         
+        
+    ], (values) => {
+    console.log(values);
+    if (values.confirmation !== frm.doc.employee){
+        frappe.throw("Invalid PF Number, Please enter the correct PF Number")
+        
+        
+    }
+        let payload = values;
+        // if payload[]
+        payload["name"] = frm.doc.name
+        frappe.call({
+            method: "core_banking.api.additional_salary.update_additional_salary",
+            args: {
+                "payload":payload
+            }
+        }).then(r=>{
+            console.log(r)
+            frm.reload_doc()
+        })
+    
+})
+}
+function showStopDialog(frm){
+    frappe.prompt([
+        {
+            //label: 'First Name',
+            fieldname: 'text_html',
+            fieldtype: 'HTML',
+            options: `<p style='color:red'>You are about to STOP <strong>${frm.doc.salary_component} (${formattedAmount(parseFloat(frm.doc.amount))})</strong> for <strong>${frm.doc.employee_name}. Please cross-check before submit to MAKE SURE of the details you provide.</strong></p>`
+        },
+            {
+            label: 'Stop Date',
+            fieldname: 'stop_date',
+            fieldtype: 'Date',
+            description: 'Please set the to date this Additional Component should be stopped.',
+            reqd: 1
+        }
+    ], (values) => {
+    if (values.stop_date < frm.doc.from_date){
+        // frappe.throw("To Date cannot be before From Date")
+    }
+    stopAdditionalSalary(frm, values.stop_date)
+    console.log(values.stop_date);
+})
+}
+function stopAdditionalSalary(frm, date){
+    let dateToUpdate = date.toString()
+    console.log("Converted String ", dateToUpdate)
+    
+    frappe.call({
+        method: "core_banking.api.additional_salary.stop_additional_salary",
+        args:{
+            "docname": frm.doc.name,
+            "stop_date": dateToUpdate
+        }
+    }).then(r=>{
+        console.log(r)
+        frm.reload_doc()
+        // frm.doc.refresh()
+        
+    })
+}
+const formattedAmount = (amount) => { return amount.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,') }


### PR DESCRIPTION
You can modify the end date of a Submitted Additional Salary without cancelling it first.

Use Case:
Additional salary is linked to multiple submitted Salary slips that you do not intend to cancel,
Changes in deduction happen before the existing additional salary expires